### PR TITLE
feat: update payment polling maxAttempts for 3-hour payment window - …

### DIFF
--- a/src/hooks/payments/use-payments.ts
+++ b/src/hooks/payments/use-payments.ts
@@ -73,7 +73,7 @@ export const usePayment = create<PaymentStore>((set, get) => ({
 	startPolling: (bookingId: string, options: PollingOptions = {}) => {
 		const {
 			interval = 5000, // Default: check every 5 seconds
-			maxAttempts = 60, // Default: try for 5 minutes (60 * 5 seconds)
+			maxAttempts = 720, // Default: try for 1 hour (720 * 5 seconds) - sufficient for 3-hour payment window
 			onSuccess,
 			onError,
 			onExpired,


### PR DESCRIPTION
…Increase maxAttempts from 60 to 720 for payment status polling - Ensures adequate polling duration for new 3-hour payment expiry