### PR TITLE
fix: update QRIS modal countdown to display hours:minutes:seconds for…

### DIFF
--- a/src/components/pages/reservation/payment/qris-modal.tsx
+++ b/src/components/pages/reservation/payment/qris-modal.tsx
@@ -68,13 +68,14 @@ export default function QRISModal({
 				return;
 			}
 
+			const hours = Math.floor(difference / (1000 * 60 * 60));
 			const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
 			const seconds = Math.floor((difference % (1000 * 60)) / 1000);
 
 			setTimeLeft(
-				`${minutes.toString().padStart(2, '0')}:${seconds
+				`${hours.toString().padStart(2, '0')}:${minutes
 					.toString()
-					.padStart(2, '0')}`,
+					.padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`,
 			);
 		};
 


### PR DESCRIPTION
…mat - Add hours calculation to countdown timer for 3-hour payment expiry - Format display as HH:MM:SS instead of MM:SS